### PR TITLE
Improve user creation

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -4,6 +4,7 @@
     user: "{{ item }}"
     state: absent
   with_items: "{{ rabbitmq_users_absent }}"
+  run_once: "{{ rabbitmq_cluster }}"
 
 - name: add rabbitmq users
   rabbitmq_user:
@@ -15,3 +16,4 @@
     write_priv: "{{ item.write_priv | default('.*') }}"
     tags: "{{ item.tags | default('') }}"
   with_items: "{{ rabbitmq_users }}"
+  run_once: "{{ rabbitmq_cluster }}"

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -17,3 +17,4 @@
     tags: "{{ item.tags | default('') }}"
   with_items: "{{ rabbitmq_users }}"
   run_once: "{{ rabbitmq_cluster }}"
+  no_log: true


### PR DESCRIPTION
Hi,

Thanks for this role! I've been using it for a few days and I noticed a few things about how RabbitMQ users are managed:
* Creation/deletion tasks are run on every node, this can lead to a race condition if nodes are clustered: all nodes thinks they should add/remove the user but only the first one gets to do it, others raise an error
* Also, the password is logged by Ansible during the creation like this:
```
ok: [my-rabbit-server] => (item={'password': 'my-password', 'tags': 'administrator', 'user': 'my-user'})
```

This PR contains fixes for these two points, do you think it could be merged?

Thank you!

P.S. : Probably more PRs to come :)
