### PR TITLE
Configurable mirroring

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,7 +33,7 @@ rabbitmq_yum_repo_gpgkey: https://packagecloud.io/rabbitmq/rabbitmq-server/gpgke
 rabbitmq_yum_repo_gpgcheck: true
 
 rabbitmq_mirroring_policy:
-  name: ha-all
+  name: ha
   pattern: .*
   tags:
     ha-mode: all

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,3 +31,9 @@ rabbitmq_yum_baseurl: https://packagecloud.io/rabbitmq/rabbitmq-server/el/7/$bas
 rabbitmq_yum_gpgcheck: false
 rabbitmq_yum_repo_gpgkey: https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey
 rabbitmq_yum_repo_gpgcheck: true
+
+rabbitmq_mirroring_policy:
+  name: ha-all
+  pattern: .*
+  tags:
+    ha-mode: all

--- a/tasks/cluster.yml
+++ b/tasks/cluster.yml
@@ -19,4 +19,7 @@
   command: rabbitmqctl start_app
 
 - name: Configure HA policy
-  command: rabbitmqctl set_policy ha-all "." '{"ha-mode":"all"}'
+  rabbitmq_policy:
+    name: "{{ rabbitmq_mirroring_policy.name }}"
+    pattern: "{{ rabbitmq_mirroring_policy.pattern }}"
+    tags: "{{ rabbitmq_mirroring_policy.tags }}"

--- a/tasks/cluster.yml
+++ b/tasks/cluster.yml
@@ -23,3 +23,4 @@
     name: "{{ rabbitmq_mirroring_policy.name }}"
     pattern: "{{ rabbitmq_mirroring_policy.pattern }}"
     tags: "{{ rabbitmq_mirroring_policy.tags }}"
+  when: rabbitmq_mirroring_policy | default(false)


### PR DESCRIPTION
Hi,

Another PR, this time about mirroring. I would like to be able to configure how my queue are mirrored, so I defined the policy in a variable. Also, I used the Ansible `rabbitmq_policy` resource instead of a `rabbitmqctl` command. The default value matches the policy you had except I changed the name to be more neutral (so that users can modify the policy content without changing its name, meaning Ansible will update it instead of replacing it).

I don't think this is a breaking change as the new policy as the same behaviour, but what do you think?

Also, users can override the policy to an empty var if they don't want mirroring at all.